### PR TITLE
Remove the from_row method which could panic because don't see the ne…

### DIFF
--- a/tokio-postgres-derive/src/lib.rs
+++ b/tokio-postgres-derive/src/lib.rs
@@ -12,7 +12,7 @@ mod from_row;
 #[proc_macro_derive(FromRow, attributes(from_row))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);
-    match from_row::try_derive_from_row(&derive_input) {
+    match from_row::derive_from_row(&derive_input) {
         Ok(result) => result,
         Err(err) => err.write_errors().into(),
     }

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -273,7 +273,7 @@ impl Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Vec<T>, Error> {
         let rows = self.query_all(sql, params).await?;
-        rows.iter().map(|x| FromRow::try_from_row(x)).collect()
+        rows.iter().map(|x| FromRow::from_row(x)).collect()
     }
 
     /// Returns a vector of scalars
@@ -326,7 +326,7 @@ impl Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<T, Error> {
         let row = self.query_one(sql, params).await?;
-        FromRow::try_from_row(&row)
+        FromRow::from_row(&row)
     }
 
     /// Like [`Client::query_scalar_one`] but returns one scalar
@@ -379,7 +379,7 @@ impl Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<T>, Error> {
         let row = self.query_opt(sql, params).await?;
-        row.map(|x| FromRow::try_from_row(&x)).transpose()
+        row.map(|x| FromRow::from_row(&x)).transpose()
     }
 
     /// Like [`Client::query_opt`] but returns an optional scalar
@@ -457,7 +457,7 @@ impl Client {
     ) -> Result<BoxStream<'static, Result<T, Error>>, Error> {
         let stream = self.stream(sql, params).await?;
         Ok(stream
-            .map(move |x| x.and_then(|x| FromRow::try_from_row(&x)))
+            .map(move |x| x.and_then(|x| FromRow::from_row(&x)))
             .boxed())
     }
 

--- a/tokio-postgres/src/from_row.rs
+++ b/tokio-postgres/src/from_row.rs
@@ -7,15 +7,8 @@ pub use tokio_postgres_derive::FromRow;
 
 /// A trait for types that can be created from a Postgres row.
 pub trait FromRow: Sized {
-    /// Performs the conversion
-    ///
-    /// # Panics
-    ///
-    /// Panics if the row does not contain the expected column names.
-    fn from_row(row: &Row) -> Self;
-
     /// Tries to perform the conversion.
     ///
     /// Will return an error if the row does not contain the expected column names.
-    fn try_from_row(row: &Row) -> Result<Self, Error>;
+    fn from_row(row: &Row) -> Result<Self, Error>;
 }


### PR DESCRIPTION
Removed the `from_row` method from `FromRow` which could panic because don't see the need for this feature. It only gives extra work when `FromRow` has to be implemented manually. 

Renamed the `try_from_row` to `from_row`