### PR TITLE
Set edition 2018

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,10 @@ jobs:
           key: test-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}y
       - run: cargo test --all
       - run: cargo test --manifest-path tokio-postgres/Cargo.toml --no-default-features
-      - run: cargo test --manifest-path tokio-postgres/Cargo.toml --all-features
+      # `with-time-0_2` and `with-time-0_3` features conflict with each other.
+      # the simplest approach is to run them separately
+      - run: cargo test --manifest-path tokio-postgres/Cargo.toml --no-default-features --features \
+          derive,array-impls,with-chrono-0_4,with-eui48-0_4,with-eui48-1,with-geo-types-0_6,with-geo-types-0_7,\
+          with-serde_json-1,with-smol_str-01,with-uuid-0_8,with-uuid-1
+      - run: cargo test --manifest-path tokio-postgres/Cargo.toml --no-default-features --features with-time-0_2
+      - run: cargo test --manifest-path tokio-postgres/Cargo.toml --no-default-features --features with-time-0_3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition = "2018"
+
 [profile.release]
 debug = 2

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codegen"
 version = "0.1.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
+edition.workspace = true
 
 [dependencies]
 phf_codegen = "0.11"

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,11 +1,6 @@
 #![warn(clippy::all)]
 #![allow(clippy::write_with_newline)]
 
-extern crate linked_hash_map;
-extern crate marksman_escape;
-extern crate phf_codegen;
-extern crate regex;
-
 mod sqlstate;
 mod type_gen;
 

--- a/codegen/src/type_gen.rs
+++ b/codegen/src/type_gen.rs
@@ -87,7 +87,7 @@ impl<'a> DatParser<'a> {
 
         loop {
             match self.it.peek() {
-                Some((_, 'a'..='z')) | Some((_, '_')) => {
+                Some((_, 'a'..='z' | '_')) => {
                     self.it.next();
                 }
                 Some((i, _)) => return self.s[start..*i].to_string(),
@@ -151,7 +151,7 @@ impl<'a> DatParser<'a> {
         loop {
             match self.it.peek() {
                 Some(&(_, '#')) => self.skip_to('\n'),
-                Some(&(_, '\n')) | Some(&(_, ' ')) | Some(&(_, '\t')) => {
+                Some(&(_, '\n') | &(_, ' ') | &(_, '\t')) => {
                     self.it.next();
                 }
                 _ => break,

--- a/postgres-derive-test/src/composites.rs
+++ b/postgres-derive-test/src/composites.rs
@@ -295,6 +295,7 @@ fn generics() {
     }
 
     // doesn't make sense to implement derived FromSql on a type with borrows
+    #[allow(explicit_outlives_requirements)]
     #[derive(ToSql, Debug, PartialEq)]
     #[postgres(name = "InventoryItem")]
     struct InventoryItemRef<'a, T: 'a + Clone, U>
@@ -339,7 +340,7 @@ fn generics() {
             (item, "ROW('foobar', 100, 15.50)"),
             (item_null, "ROW('foobar', 100, NULL)"),
         ],
-        |t: &InventoryItemRef<i32, f64>, f: &InventoryItem<i32, f64>| {
+        |t: &InventoryItemRef<'_, i32, f64>, f: &InventoryItem<i32, f64>| {
             t.name == f.name.as_str()
                 && t.supplier_id == &f.supplier_id
                 && t.price == f.price.as_ref()

--- a/postgres-derive/src/case.rs
+++ b/postgres-derive/src/case.rs
@@ -6,7 +6,10 @@ use heck::{
     ToUpperCamelCase,
 };
 
-use self::RenameRule::*;
+use self::RenameRule::{
+    CamelCase, KebabCase, LowerCase, PascalCase, ScreamingKebabCase, ScreamingSnakeCase, SnakeCase,
+    TrainCase, UpperCase,
+};
 
 /// The different possible ways to change case of fields in a struct, or variants in an enum.
 #[allow(clippy::enum_variant_names)]

--- a/postgres-derive/src/composites.rs
+++ b/postgres-derive/src/composites.rs
@@ -18,16 +18,15 @@ impl Field {
         let ident = raw.ident.as_ref().unwrap().clone();
 
         // field level name override takes precendence over container level rename_all override
-        let name = match overrides.name {
-            Some(n) => n,
-            None => {
-                let name = ident.to_string();
-                let stripped = name.strip_prefix("r#").map(String::from).unwrap_or(name);
+        let name = if let Some(n) = overrides.name {
+            n
+        } else {
+            let name = ident.to_string();
+            let stripped = name.strip_prefix("r#").map(String::from).unwrap_or(name);
 
-                match rename_all {
-                    Some(rule) => rule.apply_to_field(&stripped),
-                    None => stripped,
-                }
+            match rename_all {
+                Some(rule) => rule.apply_to_field(&stripped),
+                None => stripped,
             }
         };
 
@@ -42,7 +41,7 @@ impl Field {
 pub(crate) fn append_generic_bound(mut generics: Generics, bound: &TypeParamBound) -> Generics {
     for param in &mut generics.params {
         if let GenericParam::Type(param) = param {
-            param.bounds.push(bound.to_owned())
+            param.bounds.push(bound.clone());
         }
     }
     generics

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -237,10 +237,10 @@ fn build_generics(source: &Generics) -> (Generics, Lifetime) {
     // don't worry about lifetime name collisions, it doesn't make sense to derive FromSql on a struct with a lifetime
     let lifetime = Lifetime::new("'a", Span::call_site());
 
-    let mut out = append_generic_bound(source.to_owned(), &new_fromsql_bound(&lifetime));
+    let mut out = append_generic_bound(source.clone(), &new_fromsql_bound(&lifetime));
     out.params.insert(
         0,
-        GenericParam::Lifetime(LifetimeParam::new(lifetime.to_owned())),
+        GenericParam::Lifetime(LifetimeParam::new(lifetime.clone())),
     );
 
     (out, lifetime)
@@ -249,7 +249,7 @@ fn build_generics(source: &Generics) -> (Generics, Lifetime) {
 fn new_fromsql_bound(lifetime: &Lifetime) -> TypeParamBound {
     let mut path_segment: PathSegment = Ident::new("FromSql", Span::call_site()).into();
     let mut seg_args = Punctuated::new();
-    seg_args.push(GenericArgument::Lifetime(lifetime.to_owned()));
+    seg_args.push(GenericArgument::Lifetime(lifetime.clone()));
     path_segment.arguments = PathArguments::AngleBracketed(AngleBracketedGenericArguments {
         colon2_token: None,
         lt_token: token::Lt::default(),

--- a/postgres-derive/src/lib.rs
+++ b/postgres-derive/src/lib.rs
@@ -1,7 +1,6 @@
 //! An internal crate for `postgres-types`.
 
 #![recursion_limit = "256"]
-extern crate proc_macro;
 
 use proc_macro::TokenStream;
 

--- a/postgres-derive/src/overrides.rs
+++ b/postgres-derive/src/overrides.rs
@@ -96,7 +96,9 @@ impl Overrides {
                             return Err(Error::new_spanned(path, "unknown override"));
                         }
                     }
-                    bad => return Err(Error::new_spanned(bad, "unknown attribute")),
+                    bad @ Meta::List(_) => {
+                        return Err(Error::new_spanned(bad, "unknown attribute"))
+                    }
                 }
             }
         }

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -109,7 +109,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
     };
 
     let ident = &input.ident;
-    let generics = append_generic_bound(input.generics.to_owned(), &new_tosql_bound());
+    let generics = append_generic_bound(input.generics.clone(), &new_tosql_bound());
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let out = quote! {
         impl#impl_generics postgres_types::ToSql for #ident#ty_generics #where_clause {

--- a/postgres-openssl/src/lib.rs
+++ b/postgres-openssl/src/lib.rs
@@ -158,7 +158,8 @@ where
                 Err(error) => Err(Box::new(ConnectError {
                     error,
                     verify_result: stream.ssl().verify_result(),
-                }) as _),
+                })
+                .into()),
             }
         };
 

--- a/postgres-protocol/src/authentication/sasl.rs
+++ b/postgres-protocol/src/authentication/sasl.rs
@@ -141,7 +141,7 @@ impl ScramSha256 {
             .map(|_| {
                 let mut v = rng.gen_range(0x21u8..0x7e);
                 if v == 0x2c {
-                    v = 0x7e
+                    v = 0x7e;
                 }
                 v as char
             })

--- a/postgres-protocol/src/message/frontend.rs
+++ b/postgres-protocol/src/message/frontend.rs
@@ -6,7 +6,6 @@ use bytes::{Buf, BufMut, BytesMut};
 use std::convert::TryFrom;
 use std::error::Error;
 use std::io;
-use std::marker;
 
 use crate::{write_nullable, FromUsize, IsNull, Oid};
 
@@ -27,13 +26,13 @@ where
 }
 
 pub enum BindError {
-    Conversion(Box<dyn Error + marker::Sync + Send>),
+    Conversion(Box<dyn Error + Sync + Send>),
     Serialization(io::Error),
 }
 
-impl From<Box<dyn Error + marker::Sync + Send>> for BindError {
+impl From<Box<dyn Error + Sync + Send>> for BindError {
     #[inline]
-    fn from(e: Box<dyn Error + marker::Sync + Send>) -> BindError {
+    fn from(e: Box<dyn Error + Sync + Send>) -> BindError {
         BindError::Conversion(e)
     }
 }
@@ -58,7 +57,7 @@ pub fn bind<I, J, F, T, K>(
 where
     I: IntoIterator<Item = i16>,
     J: IntoIterator<Item = T>,
-    F: FnMut(T, &mut BytesMut) -> Result<IsNull, Box<dyn Error + marker::Sync + Send>>,
+    F: FnMut(T, &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>,
     K: IntoIterator<Item = i16>,
 {
     buf.put_u8(b'B');

--- a/postgres-protocol/src/types/test.rs
+++ b/postgres-protocol/src/types/test.rs
@@ -174,7 +174,7 @@ fn ltree_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(ltree_from_sql(query.as_slice()).is_ok())
+    assert!(ltree_from_sql(query.as_slice()).is_ok());
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn ltree_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(ltree_from_sql(query.as_slice()).is_err())
+    assert!(ltree_from_sql(query.as_slice()).is_err());
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn lquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(lquery_from_sql(query.as_slice()).is_ok())
+    assert!(lquery_from_sql(query.as_slice()).is_ok());
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn lquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("A.B.C".as_bytes());
 
-    assert!(lquery_from_sql(query.as_slice()).is_err())
+    assert!(lquery_from_sql(query.as_slice()).is_err());
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn ltxtquery_str() {
     let mut query = vec![1u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    assert!(ltree_from_sql(query.as_slice()).is_ok())
+    assert!(ltree_from_sql(query.as_slice()).is_ok());
 }
 
 #[test]
@@ -238,5 +238,5 @@ fn ltxtquery_wrong_version() {
     let mut query = vec![2u8];
     query.extend_from_slice("a & b*".as_bytes());
 
-    assert!(ltree_from_sql(query.as_slice()).is_err())
+    assert!(ltree_from_sql(query.as_slice()).is_err());
 }

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -255,6 +255,12 @@ where
     v.to_sql(ty, out)
 }
 
+#[cfg(feature = "with-time-0_2")]
+extern crate time_02 as time;
+
+#[cfg(feature = "with-time-0_3")]
+extern crate time_03 as time;
+
 #[cfg(feature = "with-bit-vec-0_6")]
 mod bit_vec_06;
 #[cfg(feature = "with-chrono-0_4")]
@@ -281,10 +287,6 @@ mod time_03;
 mod uuid_08;
 #[cfg(feature = "with-uuid-1")]
 mod uuid_1;
-
-// The time::{date, time} macros produce compile errors if the crate package is renamed.
-#[cfg(feature = "with-time-0_2")]
-extern crate time_02 as time;
 
 mod pg_lsn;
 #[doc(hidden)]

--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use postgres_protocol::types;
 use std::convert::TryFrom;
 use std::error::Error;
-use time_02::{date, time, Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+use time::{date, time, Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 use crate::{FromSql, IsNull, ToSql, Type};
 

--- a/postgres-types/src/time_03.rs
+++ b/postgres-types/src/time_03.rs
@@ -2,7 +2,7 @@ use bytes::BytesMut;
 use postgres_protocol::types;
 use std::convert::TryFrom;
 use std::error::Error;
-use time_03::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 use crate::{FromSql, IsNull, ToSql, Type};
 

--- a/postgres-types/src/type_gen.rs
+++ b/postgres-types/src/type_gen.rs
@@ -586,55 +586,18 @@ impl Inner {
 
     pub fn kind(&self) -> &Kind {
         match *self {
-            Inner::Bool => &Kind::Simple,
-            Inner::Bytea => &Kind::Simple,
-            Inner::Char => &Kind::Simple,
-            Inner::Name => &Kind::Simple,
-            Inner::Int8 => &Kind::Simple,
-            Inner::Int2 => &Kind::Simple,
-            Inner::Int2Vector => &Kind::Array(Type(Inner::Int2)),
-            Inner::Int4 => &Kind::Simple,
-            Inner::Regproc => &Kind::Simple,
-            Inner::Text => &Kind::Simple,
-            Inner::Oid => &Kind::Simple,
-            Inner::Tid => &Kind::Simple,
-            Inner::Xid => &Kind::Simple,
-            Inner::Cid => &Kind::Simple,
-            Inner::OidVector => &Kind::Array(Type(Inner::Oid)),
-            Inner::PgDdlCommand => &Kind::Pseudo,
-            Inner::Json => &Kind::Simple,
-            Inner::Xml => &Kind::Simple,
             Inner::XmlArray => &Kind::Array(Type(Inner::Xml)),
-            Inner::PgNodeTree => &Kind::Simple,
             Inner::JsonArray => &Kind::Array(Type(Inner::Json)),
-            Inner::TableAmHandler => &Kind::Pseudo,
             Inner::Xid8Array => &Kind::Array(Type(Inner::Xid8)),
-            Inner::IndexAmHandler => &Kind::Pseudo,
-            Inner::Point => &Kind::Simple,
-            Inner::Lseg => &Kind::Simple,
-            Inner::Path => &Kind::Simple,
-            Inner::Box => &Kind::Simple,
-            Inner::Polygon => &Kind::Simple,
-            Inner::Line => &Kind::Simple,
             Inner::LineArray => &Kind::Array(Type(Inner::Line)),
-            Inner::Cidr => &Kind::Simple,
             Inner::CidrArray => &Kind::Array(Type(Inner::Cidr)),
-            Inner::Float4 => &Kind::Simple,
-            Inner::Float8 => &Kind::Simple,
-            Inner::Unknown => &Kind::Simple,
-            Inner::Circle => &Kind::Simple,
             Inner::CircleArray => &Kind::Array(Type(Inner::Circle)),
-            Inner::Macaddr8 => &Kind::Simple,
             Inner::Macaddr8Array => &Kind::Array(Type(Inner::Macaddr8)),
-            Inner::Money => &Kind::Simple,
             Inner::MoneyArray => &Kind::Array(Type(Inner::Money)),
-            Inner::Macaddr => &Kind::Simple,
-            Inner::Inet => &Kind::Simple,
             Inner::BoolArray => &Kind::Array(Type(Inner::Bool)),
             Inner::ByteaArray => &Kind::Array(Type(Inner::Bytea)),
             Inner::CharArray => &Kind::Array(Type(Inner::Char)),
             Inner::NameArray => &Kind::Array(Type(Inner::Name)),
-            Inner::Int2Array => &Kind::Array(Type(Inner::Int2)),
             Inner::Int2VectorArray => &Kind::Array(Type(Inner::Int2Vector)),
             Inner::Int4Array => &Kind::Array(Type(Inner::Int4)),
             Inner::RegprocArray => &Kind::Array(Type(Inner::Regproc)),
@@ -653,80 +616,34 @@ impl Inner {
             Inner::Float4Array => &Kind::Array(Type(Inner::Float4)),
             Inner::Float8Array => &Kind::Array(Type(Inner::Float8)),
             Inner::PolygonArray => &Kind::Array(Type(Inner::Polygon)),
-            Inner::OidArray => &Kind::Array(Type(Inner::Oid)),
-            Inner::Aclitem => &Kind::Simple,
             Inner::AclitemArray => &Kind::Array(Type(Inner::Aclitem)),
             Inner::MacaddrArray => &Kind::Array(Type(Inner::Macaddr)),
             Inner::InetArray => &Kind::Array(Type(Inner::Inet)),
-            Inner::Bpchar => &Kind::Simple,
-            Inner::Varchar => &Kind::Simple,
-            Inner::Date => &Kind::Simple,
-            Inner::Time => &Kind::Simple,
-            Inner::Timestamp => &Kind::Simple,
             Inner::TimestampArray => &Kind::Array(Type(Inner::Timestamp)),
             Inner::DateArray => &Kind::Array(Type(Inner::Date)),
             Inner::TimeArray => &Kind::Array(Type(Inner::Time)),
-            Inner::Timestamptz => &Kind::Simple,
             Inner::TimestamptzArray => &Kind::Array(Type(Inner::Timestamptz)),
-            Inner::Interval => &Kind::Simple,
             Inner::IntervalArray => &Kind::Array(Type(Inner::Interval)),
             Inner::NumericArray => &Kind::Array(Type(Inner::Numeric)),
             Inner::CstringArray => &Kind::Array(Type(Inner::Cstring)),
-            Inner::Timetz => &Kind::Simple,
             Inner::TimetzArray => &Kind::Array(Type(Inner::Timetz)),
-            Inner::Bit => &Kind::Simple,
             Inner::BitArray => &Kind::Array(Type(Inner::Bit)),
-            Inner::Varbit => &Kind::Simple,
             Inner::VarbitArray => &Kind::Array(Type(Inner::Varbit)),
-            Inner::Numeric => &Kind::Simple,
-            Inner::Refcursor => &Kind::Simple,
             Inner::RefcursorArray => &Kind::Array(Type(Inner::Refcursor)),
-            Inner::Regprocedure => &Kind::Simple,
-            Inner::Regoper => &Kind::Simple,
-            Inner::Regoperator => &Kind::Simple,
-            Inner::Regclass => &Kind::Simple,
-            Inner::Regtype => &Kind::Simple,
             Inner::RegprocedureArray => &Kind::Array(Type(Inner::Regprocedure)),
             Inner::RegoperArray => &Kind::Array(Type(Inner::Regoper)),
             Inner::RegoperatorArray => &Kind::Array(Type(Inner::Regoperator)),
             Inner::RegclassArray => &Kind::Array(Type(Inner::Regclass)),
             Inner::RegtypeArray => &Kind::Array(Type(Inner::Regtype)),
-            Inner::Record => &Kind::Pseudo,
-            Inner::Cstring => &Kind::Pseudo,
-            Inner::Any => &Kind::Pseudo,
-            Inner::Anyarray => &Kind::Pseudo,
-            Inner::Void => &Kind::Pseudo,
-            Inner::Trigger => &Kind::Pseudo,
-            Inner::LanguageHandler => &Kind::Pseudo,
-            Inner::Internal => &Kind::Pseudo,
-            Inner::Anyelement => &Kind::Pseudo,
-            Inner::RecordArray => &Kind::Pseudo,
-            Inner::Anynonarray => &Kind::Pseudo,
             Inner::TxidSnapshotArray => &Kind::Array(Type(Inner::TxidSnapshot)),
-            Inner::Uuid => &Kind::Simple,
             Inner::UuidArray => &Kind::Array(Type(Inner::Uuid)),
-            Inner::TxidSnapshot => &Kind::Simple,
-            Inner::FdwHandler => &Kind::Pseudo,
-            Inner::PgLsn => &Kind::Simple,
             Inner::PgLsnArray => &Kind::Array(Type(Inner::PgLsn)),
-            Inner::TsmHandler => &Kind::Pseudo,
-            Inner::PgNdistinct => &Kind::Simple,
-            Inner::PgDependencies => &Kind::Simple,
-            Inner::Anyenum => &Kind::Pseudo,
-            Inner::TsVector => &Kind::Simple,
-            Inner::Tsquery => &Kind::Simple,
-            Inner::GtsVector => &Kind::Simple,
             Inner::TsVectorArray => &Kind::Array(Type(Inner::TsVector)),
             Inner::GtsVectorArray => &Kind::Array(Type(Inner::GtsVector)),
             Inner::TsqueryArray => &Kind::Array(Type(Inner::Tsquery)),
-            Inner::Regconfig => &Kind::Simple,
             Inner::RegconfigArray => &Kind::Array(Type(Inner::Regconfig)),
-            Inner::Regdictionary => &Kind::Simple,
             Inner::RegdictionaryArray => &Kind::Array(Type(Inner::Regdictionary)),
-            Inner::Jsonb => &Kind::Simple,
             Inner::JsonbArray => &Kind::Array(Type(Inner::Jsonb)),
-            Inner::AnyRange => &Kind::Pseudo,
-            Inner::EventTrigger => &Kind::Pseudo,
             Inner::Int4Range => &Kind::Range(Type(Inner::Int4)),
             Inner::Int4RangeArray => &Kind::Array(Type(Inner::Int4Range)),
             Inner::NumRange => &Kind::Range(Type(Inner::Numeric)),
@@ -739,13 +656,9 @@ impl Inner {
             Inner::DateRangeArray => &Kind::Array(Type(Inner::DateRange)),
             Inner::Int8Range => &Kind::Range(Type(Inner::Int8)),
             Inner::Int8RangeArray => &Kind::Array(Type(Inner::Int8Range)),
-            Inner::Jsonpath => &Kind::Simple,
             Inner::JsonpathArray => &Kind::Array(Type(Inner::Jsonpath)),
-            Inner::Regnamespace => &Kind::Simple,
             Inner::RegnamespaceArray => &Kind::Array(Type(Inner::Regnamespace)),
-            Inner::Regrole => &Kind::Simple,
             Inner::RegroleArray => &Kind::Array(Type(Inner::Regrole)),
-            Inner::Regcollation => &Kind::Simple,
             Inner::RegcollationArray => &Kind::Array(Type(Inner::Regcollation)),
             Inner::Int4multiRange => &Kind::Multirange(Type(Inner::Int4)),
             Inner::NummultiRange => &Kind::Multirange(Type(Inner::Numeric)),
@@ -753,18 +666,107 @@ impl Inner {
             Inner::TstzmultiRange => &Kind::Multirange(Type(Inner::Timestamptz)),
             Inner::DatemultiRange => &Kind::Multirange(Type(Inner::Date)),
             Inner::Int8multiRange => &Kind::Multirange(Type(Inner::Int8)),
-            Inner::AnymultiRange => &Kind::Pseudo,
-            Inner::AnycompatiblemultiRange => &Kind::Pseudo,
-            Inner::PgBrinBloomSummary => &Kind::Simple,
-            Inner::PgBrinMinmaxMultiSummary => &Kind::Simple,
-            Inner::PgMcvList => &Kind::Simple,
-            Inner::PgSnapshot => &Kind::Simple,
             Inner::PgSnapshotArray => &Kind::Array(Type(Inner::PgSnapshot)),
-            Inner::Xid8 => &Kind::Simple,
-            Inner::Anycompatible => &Kind::Pseudo,
-            Inner::Anycompatiblearray => &Kind::Pseudo,
-            Inner::Anycompatiblenonarray => &Kind::Pseudo,
-            Inner::AnycompatibleRange => &Kind::Pseudo,
+
+            Inner::OidVector | Inner::OidArray => &Kind::Array(Type(Inner::Oid)),
+            Inner::Int2Vector | Inner::Int2Array => &Kind::Array(Type(Inner::Int2)),
+
+            Inner::PgDdlCommand
+            | Inner::TableAmHandler
+            | Inner::IndexAmHandler
+            | Inner::FdwHandler
+            | Inner::TsmHandler
+            | Inner::Anyenum
+            | Inner::Bool
+            | Inner::Bytea
+            | Inner::Char
+            | Inner::Name
+            | Inner::Int8
+            | Inner::Int2
+            | Inner::Int4
+            | Inner::Regproc
+            | Inner::Text
+            | Inner::Oid
+            | Inner::Tid
+            | Inner::Xid
+            | Inner::Cid
+            | Inner::Json
+            | Inner::Xml
+            | Inner::PgNodeTree
+            | Inner::Point
+            | Inner::Lseg
+            | Inner::Path
+            | Inner::Box
+            | Inner::Polygon
+            | Inner::Line
+            | Inner::Cidr
+            | Inner::Float4
+            | Inner::Float8
+            | Inner::Unknown
+            | Inner::Circle
+            | Inner::Macaddr8
+            | Inner::Money
+            | Inner::Macaddr
+            | Inner::Inet
+            | Inner::Aclitem
+            | Inner::Bpchar
+            | Inner::Varchar
+            | Inner::Date
+            | Inner::Time
+            | Inner::Timestamp
+            | Inner::Timestamptz
+            | Inner::Interval
+            | Inner::Timetz
+            | Inner::Bit
+            | Inner::Varbit
+            | Inner::Numeric
+            | Inner::Refcursor
+            | Inner::Regprocedure
+            | Inner::Regoper
+            | Inner::Regoperator
+            | Inner::Regclass
+            | Inner::Regtype
+            | Inner::Uuid
+            | Inner::TxidSnapshot
+            | Inner::PgLsn
+            | Inner::PgNdistinct
+            | Inner::PgDependencies
+            | Inner::TsVector
+            | Inner::Tsquery
+            | Inner::GtsVector
+            | Inner::Regconfig
+            | Inner::Regdictionary
+            | Inner::Jsonb
+            | Inner::Jsonpath
+            | Inner::Regnamespace
+            | Inner::Regrole
+            | Inner::Regcollation
+            | Inner::PgBrinBloomSummary
+            | Inner::PgBrinMinmaxMultiSummary
+            | Inner::PgMcvList
+            | Inner::PgSnapshot
+            | Inner::Xid8 => &Kind::Simple,
+
+            Inner::AnyRange
+            | Inner::EventTrigger
+            | Inner::AnymultiRange
+            | Inner::Record
+            | Inner::Cstring
+            | Inner::Any
+            | Inner::Anyarray
+            | Inner::Void
+            | Inner::Trigger
+            | Inner::LanguageHandler
+            | Inner::Internal
+            | Inner::Anyelement
+            | Inner::RecordArray
+            | Inner::Anynonarray
+            | Inner::AnycompatiblemultiRange
+            | Inner::Anycompatible
+            | Inner::Anycompatiblearray
+            | Inner::Anycompatiblenonarray
+            | Inner::AnycompatibleRange => &Kind::Pseudo,
+
             Inner::Int4multiRangeArray => &Kind::Array(Type(Inner::Int4multiRange)),
             Inner::NummultiRangeArray => &Kind::Array(Type(Inner::NummultiRange)),
             Inner::TsmultiRangeArray => &Kind::Array(Type(Inner::TsmultiRange)),

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -17,7 +17,7 @@ pub struct Client {
 
 impl Drop for Client {
     fn drop(&mut self) {
-        let _ = self.close_inner();
+        let _unused = self.close_inner();
     }
 }
 

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -466,7 +466,7 @@ impl From<tokio_postgres::Config> for Config {
         Config {
             config,
             notice_callback: Arc::new(|notice| {
-                info!("{}: {}", notice.severity(), notice.message())
+                info!("{}: {}", notice.severity(), notice.message());
             }),
         }
     }

--- a/postgres/src/connection.rs
+++ b/postgres/src/connection.rs
@@ -71,7 +71,7 @@ impl Connection {
                             notifications.push_back(notification);
                         }
                         Poll::Ready(Some(Ok(AsyncMessage::Notice(notice)))) => {
-                            notice_callback(notice)
+                            notice_callback(notice);
                         }
                         Poll::Ready(Some(Ok(_))) => {}
                         Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e)),

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -15,7 +15,7 @@ pub struct Transaction<'a> {
 impl<'a> Drop for Transaction<'a> {
     fn drop(&mut self) {
         if let Some(transaction) = self.transaction.take() {
-            let _ = self.connection.block_on(transaction.rollback());
+            let _unused = self.connection.block_on(transaction.rollback());
         }
     }
 }

--- a/tokio-postgres-derive-test/src/from_row.rs
+++ b/tokio-postgres-derive-test/src/from_row.rs
@@ -33,7 +33,7 @@ async fn query_all_as() {
     assert_eq!(users.len(), 1);
     let user = users.get(0).unwrap();
     assert_eq!(user.name, "steven");
-    assert_eq!(user.age, 18)
+    assert_eq!(user.age, 18);
 }
 
 async fn connect(s: &str) -> Client {

--- a/tokio-postgres-derive/src/from_row.rs
+++ b/tokio-postgres-derive/src/from_row.rs
@@ -50,7 +50,7 @@ impl DeriveFromRow {
 
         let mut predicates = Vec::new();
         for field in &self.fields {
-            field.push_predicates(&mut predicates)
+            field.push_predicates(&mut predicates);
         }
 
         let from_row_fields = self
@@ -132,13 +132,13 @@ impl FromRowField {
         let ty = &self.ty;
 
         if self.attrs.flatten {
-            predicates.push(quote! (#target_ty: ::tokio_postgres::FromRow))
+            predicates.push(quote! (#target_ty: ::tokio_postgres::FromRow));
         } else {
-            predicates.push(quote! (#target_ty: for<'a> ::tokio_postgres::types::FromSql<'a>))
+            predicates.push(quote! (#target_ty: for<'a> ::tokio_postgres::types::FromSql<'a>));
         };
 
         if self.attrs.from.is_some() {
-            predicates.push(quote!(#ty: std::convert::From<#target_ty>))
+            predicates.push(quote!(#ty: std::convert::From<#target_ty>));
         } else if self.attrs.try_from.is_some() {
             let try_from = quote!(::std::convert::TryFrom<#target_ty>);
 
@@ -200,16 +200,16 @@ impl FromRowFieldAttrs {
 
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("flatten") {
-                    this.flatten = true
+                    this.flatten = true;
                 } else if meta.path.is_ident("try_from") {
                     let lit: syn::LitStr = meta.value()?.parse()?;
-                    this.try_from = Some(lit.parse()?)
+                    this.try_from = Some(lit.parse()?);
                 } else if meta.path.is_ident("from") {
                     let lit: syn::LitStr = meta.value()?.parse()?;
-                    this.from = Some(lit.parse()?)
+                    this.from = Some(lit.parse()?);
                 } else if meta.path.is_ident("rename") {
                     let lit: syn::LitStr = meta.value()?.parse()?;
-                    this.rename = Some(lit.value())
+                    this.rename = Some(lit.value());
                 } else {
                     return Err(meta.error("unexpected `from_row` attribute."));
                 }

--- a/tokio-postgres-derive/src/lib.rs
+++ b/tokio-postgres-derive/src/lib.rs
@@ -1,7 +1,6 @@
 //! An internal crate for `tokio-postgres`.
 
 #![recursion_limit = "256"]
-extern crate proc_macro;
 
 use proc_macro::TokenStream;
 

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -603,7 +603,7 @@ impl Client {
                     frontend::query("ROLLBACK", buf).unwrap();
                     buf.split().freeze()
                 });
-                let _ = self
+                let _unused = self
                     .client
                     .inner()
                     .send(RequestMessages::Single(FrontendMessage::Raw(buf)));
@@ -691,7 +691,7 @@ impl Client {
 
     #[doc(hidden)]
     pub fn __private_api_close(&mut self) {
-        self.inner.sender.close_channel()
+        self.inner.sender.close_channel();
     }
 }
 

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -15,7 +15,6 @@ use std::borrow::Cow;
 #[cfg(unix)]
 use std::ffi::OsStr;
 use std::net::IpAddr;
-use std::ops::Deref;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
@@ -347,7 +346,7 @@ impl Config {
 
     /// Gets the hostaddrs that have been added to the configuration with `hostaddr`.
     pub fn get_hostaddrs(&self) -> &[IpAddr] {
-        self.hostaddr.deref()
+        &self.hostaddr
     }
 
     /// Adds a Unix socket host to the configuration.
@@ -1107,6 +1106,7 @@ impl<'a> UrlParser<'a> {
         self.config.param("host", &s)
     }
 
+    #[allow(clippy::unused_self)]
     fn decode(&self, s: &'a str) -> Result<Cow<'a, str>, Error> {
         percent_encoding::percent_decode(s.as_bytes())
             .decode_utf8()

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -181,10 +181,12 @@ where
         Some(Message::AuthenticationSasl(body)) => {
             authenticate_sasl(stream, body, config).await?;
         }
-        Some(Message::AuthenticationKerberosV5)
-        | Some(Message::AuthenticationScmCredential)
-        | Some(Message::AuthenticationGss)
-        | Some(Message::AuthenticationSspi) => {
+        Some(
+            Message::AuthenticationKerberosV5
+            | Message::AuthenticationScmCredential
+            | Message::AuthenticationGss
+            | Message::AuthenticationSspi,
+        ) => {
             return Err(Error::authentication(
                 "unsupported authentication method".into(),
             ))
@@ -344,7 +346,7 @@ where
                 );
             }
             Some(msg @ Message::NoticeResponse(_)) => {
-                stream.delayed.push_back(BackendMessage::Async(msg))
+                stream.delayed.push_back(BackendMessage::Async(msg));
             }
             Some(Message::ReadyForQuery(_)) => return Ok((process_id, secret_key, parameters)),
             Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -145,7 +145,7 @@ where
 
             match response.sender.poll_ready(cx) {
                 Poll::Ready(Ok(())) => {
-                    let _ = response.sender.start_send(messages);
+                    let _unused = response.sender.start_send(messages);
                     if !request_complete {
                         self.responses.push_front(response);
                     }

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -385,7 +385,7 @@ impl fmt::Display for Error {
             Kind::FromSql(idx) => write!(fmt, "error deserializing column {}", idx)?,
             Kind::Column(column) => write!(fmt, "invalid column `{}`", column)?,
             Kind::Parameters(real, expected) => {
-                write!(fmt, "expected {expected} parameters but got {real}")?
+                write!(fmt, "expected {expected} parameters but got {real}")?;
             }
             Kind::Closed => fmt.write_str("connection closed")?,
             Kind::Db => fmt.write_str("db error")?,
@@ -408,7 +408,10 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        self.0.cause.as_ref().map(|e| &**e as _)
+        self.0
+            .cause
+            .as_deref()
+            .map::<&(dyn error::Error + 'static), _>(|e| e)
     }
 }
 

--- a/tokio-postgres/src/portal.rs
+++ b/tokio-postgres/src/portal.rs
@@ -19,7 +19,7 @@ impl Drop for Inner {
                 frontend::sync(buf);
                 buf.split().freeze()
             });
-            let _ = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+            let _unused = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
         }
     }
 }

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -184,7 +184,7 @@ impl Row {
 
     /// Get the raw bytes for the column at the given index.
     fn col_buffer(&self, idx: usize) -> Option<&[u8]> {
-        let range = self.ranges[idx].to_owned()?;
+        let range = self.ranges[idx].clone()?;
         Some(&self.body.buffer()[range])
     }
 }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -23,7 +23,7 @@ impl Drop for StatementInner {
                 frontend::sync(buf);
                 buf.split().freeze()
             });
-            let _ = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+            let _unused = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
         }
     }
 }

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -50,7 +50,7 @@ impl<'a> Drop for Transaction<'a> {
             frontend::query(&query, buf).unwrap();
             buf.split().freeze()
         });
-        let _ = self
+        let _unused = self
             .client
             .inner()
             .send(RequestMessages::Single(FrontendMessage::Raw(buf)));

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -318,15 +318,13 @@ async fn simple_query() {
         .await
         .unwrap();
 
-    match messages[0] {
-        SimpleQueryMessage::CommandComplete(0) => {}
-        _ => panic!("unexpected message"),
-    }
-    match messages[1] {
-        SimpleQueryMessage::CommandComplete(2) => {}
-        _ => panic!("unexpected message"),
-    }
-    match &messages[2] {
+    let [SimpleQueryMessage::CommandComplete(0), SimpleQueryMessage::CommandComplete(2), ref third, ref forth, SimpleQueryMessage::CommandComplete(2)] =
+        messages[..]
+    else {
+        panic!("unexpected message")
+    };
+
+    match third {
         SimpleQueryMessage::Row(row) => {
             assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
             assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
@@ -335,17 +333,13 @@ async fn simple_query() {
         }
         _ => panic!("unexpected message"),
     }
-    match &messages[3] {
+    match forth {
         SimpleQueryMessage::Row(row) => {
             assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
             assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
             assert_eq!(row.get(0), Some("2"));
             assert_eq!(row.get(1), Some("joe"));
         }
-        _ => panic!("unexpected message"),
-    }
-    match messages[4] {
-        SimpleQueryMessage::CommandComplete(2) => {}
         _ => panic!("unexpected message"),
     }
     assert_eq!(messages.len(), 5);

--- a/tokio-postgres/tests/test/parse.rs
+++ b/tokio-postgres/tests/test/parse.rs
@@ -128,5 +128,5 @@ fn url() {
             .host_path("/var/lib/postgresql")
             .port(5432)
             .dbname("dbname"),
-    )
+    );
 }

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -68,7 +68,7 @@ async fn target_session_attrs_err() {
 
 #[tokio::test]
 async fn host_only_ok() {
-    let _ = tokio_postgres::connect(
+    let _unused = tokio_postgres::connect(
         "host=localhost port=5433 user=pass_user dbname=postgres password=password",
         NoTls,
     )
@@ -78,7 +78,7 @@ async fn host_only_ok() {
 
 #[tokio::test]
 async fn hostaddr_only_ok() {
-    let _ = tokio_postgres::connect(
+    let _unused = tokio_postgres::connect(
         "hostaddr=127.0.0.1 port=5433 user=pass_user dbname=postgres password=password",
         NoTls,
     )
@@ -88,7 +88,7 @@ async fn hostaddr_only_ok() {
 
 #[tokio::test]
 async fn hostaddr_and_host_ok() {
-    let _ = tokio_postgres::connect(
+    let _unused = tokio_postgres::connect(
         "hostaddr=127.0.0.1 host=localhost port=5433 user=pass_user dbname=postgres password=password",
         NoTls,
     )
@@ -98,7 +98,7 @@ async fn hostaddr_and_host_ok() {
 
 #[tokio::test]
 async fn hostaddr_host_mismatch() {
-    let _ = tokio_postgres::connect(
+    let _unused = tokio_postgres::connect(
         "hostaddr=127.0.0.1,127.0.0.2 host=localhost port=5433 user=pass_user dbname=postgres password=password",
         NoTls,
     )
@@ -109,7 +109,7 @@ async fn hostaddr_host_mismatch() {
 
 #[tokio::test]
 async fn hostaddr_host_both_missing() {
-    let _ = tokio_postgres::connect(
+    let _unused = tokio_postgres::connect(
         "port=5433 user=pass_user dbname=postgres password=password",
         NoTls,
     )

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -5,7 +5,6 @@ use std::f32;
 use std::f64;
 use std::fmt;
 use std::net::IpAddr;
-use std::result;
 use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 use tokio_postgres::types::{FromSql, FromSqlOwned, IsNull, Kind, PgLsn, ToSql, Type, WrongType};
@@ -151,7 +150,7 @@ async fn test_lsn_params() {
             (None, "NULL"),
         ],
     )
-    .await
+    .await;
 }
 
 #[tokio::test]
@@ -372,11 +371,7 @@ async fn test_array_vec_params() {
 async fn test_array_array_params() {
     test_type("integer[]", &[(Some([1i32, 2i32]), "ARRAY[1,2]")]).await;
     test_type("text[]", &[(Some(["peter".to_string()]), "ARRAY['peter']")]).await;
-    test_type(
-        "integer[]",
-        &[(Some([] as [i32; 0]), "ARRAY[]"), (None, "NULL")],
-    )
-    .await;
+    test_type::<Option<[i32; 0]>, _>("integer[]", &[(Some([]), "ARRAY[]"), (None, "NULL")]).await;
 }
 
 #[allow(clippy::eq_op)]
@@ -492,7 +487,7 @@ async fn domain() {
             &self,
             ty: &Type,
             out: &mut BytesMut,
-        ) -> result::Result<IsNull, Box<dyn Error + Sync + Send>> {
+        ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
             let inner = match *ty.kind() {
                 Kind::Domain(ref inner) => inner,
                 _ => unreachable!(),
@@ -508,7 +503,7 @@ async fn domain() {
     }
 
     impl<'a> FromSql<'a> for SessionId {
-        fn from_sql(ty: &Type, raw: &[u8]) -> result::Result<Self, Box<dyn Error + Sync + Send>> {
+        fn from_sql(ty: &Type, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
             Vec::<u8>::from_sql(ty, raw).map(SessionId)
         }
 


### PR DESCRIPTION
I don't see what benefit not setting the `package.edition` provides. 
If it's not set then `edition = 2015` is assumed.

For now I'm going to set the edition to 2018 and fix up the issues that arise.

For the future, given how the [edition system works](https://doc.rust-lang.org/book/appendix-05-editions.html) I don't see any reason to not set the edition to 2021. 

Does anyone (@rikvdkleij, @maospr, @rudolphfroger, @ds-cbo, @remkop22) have any objections?  
