### PR TITLE
Add `query` to `Error`

### DIFF
--- a/tokio-postgres-derive-test/src/from_row.rs
+++ b/tokio-postgres-derive-test/src/from_row.rs
@@ -11,7 +11,7 @@ async fn connect(s: &str) -> Client {
     client
 }
 
-async fn query_row<T: FromRow>() -> Result<Vec<T>, tokio_postgres::Error> {
+async fn query_row<R: FromRow>() -> Result<Vec<R>, tokio_postgres::Error> {
     let client = connect("user=postgres host=localhost port=5433").await;
     client
         .batch_execute(
@@ -27,7 +27,7 @@ async fn query_row<T: FromRow>() -> Result<Vec<T>, tokio_postgres::Error> {
         .unwrap();
 
     client
-        .query_as::<T>("SELECT name, age FROM person", &[])
+        .query_as::<_, R>("SELECT name, age FROM person", &[])
         .await
 }
 

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -105,7 +105,13 @@ pub async fn prepare(
         }
     }
 
-    Ok(Statement::new(client, name, parameters, columns))
+    Ok(Statement::new(
+        client,
+        query.to_string(),
+        name,
+        parameters,
+        columns,
+    ))
 }
 
 fn prepare_rec<'a>(

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -1,5 +1,6 @@
 //! Rows.
 
+use crate::error::WithQuery;
 use crate::row::sealed::{AsName, Sealed};
 use crate::simple_query::SimpleColumn;
 use crate::statement::Column;
@@ -111,7 +112,11 @@ impl fmt::Debug for Row {
 
 impl Row {
     pub(crate) fn new(statement: Statement, body: DataRowBody) -> Result<Row, Error> {
-        let ranges = body.ranges().collect().map_err(Error::parse)?;
+        let ranges = body
+            .ranges()
+            .collect()
+            .map_err(Error::parse)
+            .with_query(|| statement.query().to_string())?;
         Ok(Row {
             statement,
             body,

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Weak};
 
 struct StatementInner {
     client: Weak<InnerClient>,
+    query: String,
     name: String,
     params: Vec<Type>,
     columns: Vec<Column>,
@@ -34,12 +35,14 @@ pub struct Statement(Arc<StatementInner>);
 impl Statement {
     pub(crate) fn new(
         inner: &Arc<InnerClient>,
+        query: String,
         name: String,
         params: Vec<Type>,
         columns: Vec<Column>,
     ) -> Statement {
         Statement(Arc::new(StatementInner {
             client: Arc::downgrade(inner),
+            query,
             name,
             params,
             columns,
@@ -58,6 +61,11 @@ impl Statement {
     /// Returns information about the columns returned when the statement is queried.
     pub fn columns(&self) -> &[Column] {
         &self.0.columns
+    }
+
+    /// Returns the source query used to construct this statement.
+    pub fn query(&self) -> &str {
+        &self.0.query
     }
 }
 

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -1,21 +1,23 @@
-use crate::to_statement::private::{Sealed, ToStatementType};
+use crate::to_statement::private::Sealed;
 use crate::Statement;
 
-mod private {
+pub(crate) use private::StatementType;
+
+pub(crate) mod private {
     use crate::{Client, Error, Statement};
 
     pub trait Sealed {}
 
-    pub enum ToStatementType<'a> {
+    pub enum StatementType<'a> {
         Statement(&'a Statement),
         Query(&'a str),
     }
 
-    impl<'a> ToStatementType<'a> {
+    impl<'a> StatementType<'a> {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
-                ToStatementType::Statement(s) => Ok(s.clone()),
-                ToStatementType::Query(s) => client.prepare(s).await,
+                StatementType::Statement(s) => Ok(s.clone()),
+                StatementType::Query(s) => client.prepare(s).await,
             }
         }
     }
@@ -29,28 +31,28 @@ mod private {
 /// This trait is "sealed" and cannot be implemented by anything outside this crate.
 pub trait ToStatement: Sealed {
     #[doc(hidden)]
-    fn __convert(&self) -> ToStatementType<'_>;
+    fn __convert(&self) -> StatementType<'_>;
 }
 
 impl ToStatement for Statement {
-    fn __convert(&self) -> ToStatementType<'_> {
-        ToStatementType::Statement(self)
+    fn __convert(&self) -> StatementType<'_> {
+        StatementType::Statement(self)
     }
 }
 
 impl Sealed for Statement {}
 
 impl ToStatement for str {
-    fn __convert(&self) -> ToStatementType<'_> {
-        ToStatementType::Query(self)
+    fn __convert(&self) -> StatementType<'_> {
+        StatementType::Query(self)
     }
 }
 
 impl Sealed for str {}
 
 impl ToStatement for String {
-    fn __convert(&self) -> ToStatementType<'_> {
-        ToStatementType::Query(self)
+    fn __convert(&self) -> StatementType<'_> {
+        StatementType::Query(self)
     }
 }
 

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -117,21 +117,27 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like [`Client::query_as`]
-    pub async fn query_as<T: FromRow>(
+    pub async fn query_as<T, R: FromRow>(
         &self,
-        sql: &str,
+        statement: &T,
         params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<T>, Error> {
-        self.client.query_as(sql, params).await
+    ) -> Result<Vec<R>, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        self.client.query_as(statement, params).await
     }
 
     /// Like [`Client::query_scalar`]
-    pub async fn query_scalar<T: FromSqlOwned>(
+    pub async fn query_scalar<T, R: FromSqlOwned>(
         &self,
-        sql: &str,
+        statement: &T,
         params: &[&(dyn ToSql + Sync)],
-    ) -> Result<Vec<T>, Error> {
-        self.client.query_scalar(sql, params).await
+    ) -> Result<Vec<R>, Error>
+    where
+        T: ?Sized + ToStatement,
+    {
+        self.client.query_scalar(statement, params).await
     }
 
     /// Like [`Client::query_one`]


### PR DESCRIPTION
Add a `query` field to `Error` that allows the query associated with an `Error` to be capture and displayed to the user.

The query capture is accomplished though the `error::WithQuery` trait, which sets (mutates) an existing `Error`.
This trait based method is used as we sometimes need to capture the query after the `Error` has been created.
 