### PR TITLE
Replace `log` with `tracing`

### DIFF
--- a/postgres-native-tls/src/lib.rs
+++ b/postgres-native-tls/src/lib.rs
@@ -70,7 +70,7 @@ mod test;
 ///
 /// Requires the `runtime` Cargo feature (enabled by default).
 #[cfg(feature = "runtime")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MakeTlsConnector(native_tls::TlsConnector);
 
 #[cfg(feature = "runtime")]

--- a/postgres-openssl/src/lib.rs
+++ b/postgres-openssl/src/lib.rs
@@ -86,6 +86,12 @@ pub struct MakeTlsConnector {
     config: Arc<ConfigCallback>,
 }
 
+impl fmt::Debug for MakeTlsConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.connector, f)
+    }
+}
+
 #[cfg(feature = "runtime")]
 impl MakeTlsConnector {
     /// Creates a new connector.

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -39,7 +39,7 @@ with-time-0_3 = ["tokio-postgres/with-time-0_3"]
 bytes = "1.0"
 fallible-iterator = "0.2"
 futures-util = { version = "0.3.14", features = ["sink"] }
-log = "0.4"
+tracing = "0.1"
 tokio-postgres = { version = "0.7.10", path = "../tokio-postgres" }
 tokio = { version = "1.0", features = ["rt", "time"] }
 

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -2,7 +2,6 @@
 
 use crate::connection::Connection;
 use crate::Client;
-use log::info;
 use std::fmt;
 use std::net::IpAddr;
 use std::path::Path;
@@ -17,6 +16,7 @@ pub use tokio_postgres::config::{
 use tokio_postgres::error::DbError;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 use tokio_postgres::{Error, Socket};
+use tracing::info;
 
 /// Connection configuration.
 ///

--- a/postgres/src/generic_client.rs
+++ b/postgres/src/generic_client.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{
     Client, CopyInWriter, CopyOutReader, Error, Row, RowIter, SimpleQueryMessage, Statement,
@@ -15,17 +17,17 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::execute`.
     fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::query`.
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::query_one`.
     fn query_one<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::query_opt`.
     fn query_opt<T>(
@@ -34,12 +36,12 @@ pub trait GenericClient: private::Sealed {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::query_raw`.
     fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator;
@@ -53,12 +55,12 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::copy_in`.
     fn copy_in<T>(&mut self, query: &T) -> Result<CopyInWriter<'_>, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::copy_out`.
     fn copy_out<T>(&mut self, query: &T) -> Result<CopyOutReader<'_>, Error>
     where
-        T: ?Sized + ToStatement;
+        T: ?Sized + ToStatement + fmt::Debug;
 
     /// Like `Client::simple_query`.
     fn simple_query(&mut self, query: &str) -> Result<Vec<SimpleQueryMessage>, Error>;
@@ -75,21 +77,21 @@ impl private::Sealed for Client {}
 impl GenericClient for Client {
     fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.execute(query, params)
     }
 
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query(query, params)
     }
 
     fn query_one<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query_one(query, params)
     }
@@ -100,14 +102,14 @@ impl GenericClient for Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query_opt(query, params)
     }
 
     fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
@@ -125,14 +127,14 @@ impl GenericClient for Client {
 
     fn copy_in<T>(&mut self, query: &T) -> Result<CopyInWriter<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.copy_in(query)
     }
 
     fn copy_out<T>(&mut self, query: &T) -> Result<CopyOutReader<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.copy_out(query)
     }
@@ -155,21 +157,21 @@ impl private::Sealed for Transaction<'_> {}
 impl GenericClient for Transaction<'_> {
     fn execute<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.execute(query, params)
     }
 
     fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query(query, params)
     }
 
     fn query_one<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query_one(query, params)
     }
@@ -180,14 +182,14 @@ impl GenericClient for Transaction<'_> {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.query_opt(query, params)
     }
 
     fn query_raw<T, P, I>(&mut self, query: &T, params: I) -> Result<RowIter<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
@@ -205,14 +207,14 @@ impl GenericClient for Transaction<'_> {
 
     fn copy_in<T>(&mut self, query: &T) -> Result<CopyInWriter<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.copy_in(query)
     }
 
     fn copy_out<T>(&mut self, query: &T) -> Result<CopyOutReader<'_>, Error>
     where
-        T: ?Sized + ToStatement,
+        T: ?Sized + ToStatement + fmt::Debug,
     {
         self.copy_out(query)
     }

--- a/tokio-postgres-derive-test/src/from_row.rs
+++ b/tokio-postgres-derive-test/src/from_row.rs
@@ -11,7 +11,7 @@ async fn connect(s: &str) -> Client {
     client
 }
 
-async fn query_row<T: FromRow>() -> Result<Vec<T>, tokio_postgres::Error> {
+async fn query_row<R: FromRow>() -> Result<Vec<R>, tokio_postgres::Error> {
     let client = connect("user=postgres host=localhost port=5433").await;
     client
         .batch_execute(
@@ -27,7 +27,7 @@ async fn query_row<T: FromRow>() -> Result<Vec<T>, tokio_postgres::Error> {
         .unwrap();
 
     client
-        .query_as::<T>("SELECT name, age FROM person", &[])
+        .query_as::<_, R>("SELECT name, age FROM person", &[])
         .await
 }
 

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -70,7 +70,6 @@ socket2 = { version = "0.5", features = ["all"] }
 [dev-dependencies]
 futures-executor = "0.3"
 criterion = "0.5"
-env_logger = "0.11"
 tokio = { version = "1.0", features = [
     "macros",
     "net",

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -51,7 +51,7 @@ byteorder = "1.0"
 fallible-iterator = "0.2"
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", features = ["sink"] }
-log = "0.4"
+tracing = "0.1"
 parking_lot = "0.12"
 percent-encoding = "2.0"
 pin-project-lite = "0.2"

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -7,7 +7,6 @@ use bytes::BytesMut;
 use fallible_iterator::FallibleIterator;
 use futures_channel::mpsc;
 use futures_util::{ready, stream::FusedStream, Sink, Stream, StreamExt};
-use log::{info, trace};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::collections::{HashMap, VecDeque};
@@ -16,6 +15,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
+use tracing::{info, trace};
 
 pub enum RequestMessages {
     Single(FrontendMessage),

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -6,7 +6,6 @@ use crate::{query, slice_iter, Error, Statement};
 use bytes::{Buf, BufMut, BytesMut};
 use futures_channel::mpsc;
 use futures_util::{future, ready, Sink, SinkExt, Stream, StreamExt};
-use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
@@ -14,6 +13,7 @@ use postgres_protocol::message::frontend::CopyData;
 use std::marker::{PhantomData, PhantomPinned};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tracing::debug;
 
 enum CopyInMessage {
     Message(FrontendMessage),

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -4,12 +4,12 @@ use crate::connection::RequestMessages;
 use crate::{query, slice_iter, Error, Statement};
 use bytes::Bytes;
 use futures_util::{ready, Stream};
-use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tracing::debug;
 
 pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<CopyOutStream, Error> {
     debug!("executing copy out statement {}", statement.name());

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::query::RowStream;
 use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{Client, Error, Row, Statement, ToStatement, Transaction};
@@ -15,12 +17,12 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug;
 
     /// Like `Client::execute_raw`.
     async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator;
@@ -28,7 +30,7 @@ pub trait GenericClient: private::Sealed {
     /// Like `Client::query`.
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug;
 
     /// Like `Client::query_one`.
     async fn query_one<T>(
@@ -37,7 +39,7 @@ pub trait GenericClient: private::Sealed {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug;
 
     /// Like `Client::query_opt`.
     async fn query_opt<T>(
@@ -46,12 +48,12 @@ pub trait GenericClient: private::Sealed {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send;
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug;
 
     /// Like `Client::query_raw`.
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator;
@@ -82,14 +84,14 @@ impl private::Sealed for Client {}
 impl GenericClient for Client {
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.execute(query, params).await
     }
 
     async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
@@ -99,7 +101,7 @@ impl GenericClient for Client {
 
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query(query, params).await
     }
@@ -110,7 +112,7 @@ impl GenericClient for Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query_one(statement, params).await
     }
@@ -121,14 +123,14 @@ impl GenericClient for Client {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query_opt(statement, params).await
     }
 
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
@@ -168,14 +170,14 @@ impl private::Sealed for Transaction<'_> {}
 impl GenericClient for Transaction<'_> {
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.execute(query, params).await
     }
 
     async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
@@ -185,7 +187,7 @@ impl GenericClient for Transaction<'_> {
 
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug + fmt::Debug,
     {
         self.query(query, params).await
     }
@@ -196,7 +198,7 @@ impl GenericClient for Transaction<'_> {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Row, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query_one(statement, params).await
     }
@@ -207,14 +209,14 @@ impl GenericClient for Transaction<'_> {
         params: &[&(dyn ToSql + Sync)],
     ) -> Result<Option<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query_opt(statement, params).await
     }
 
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -177,7 +177,7 @@ impl GenericClient for Transaction<'_> {
 
     async fn execute_raw<P, I, T>(&self, statement: &T, params: I) -> Result<u64, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send + fmt::Debug + fmt::Debug,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
         P: BorrowToSql,
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
@@ -187,7 +187,7 @@ impl GenericClient for Transaction<'_> {
 
     async fn query<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send + fmt::Debug + fmt::Debug,
+        T: ?Sized + ToStatement + Sync + Send + fmt::Debug,
     {
         self.query(query, params).await
     }

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -142,8 +142,6 @@ pub use crate::to_statement::ToStatement;
 pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
-use std::fmt;
-use tracing::instrument;
 
 pub mod binary_copy;
 mod bind;
@@ -191,13 +189,13 @@ pub mod types;
 ///
 /// [`Config`]: config/struct.Config.html
 #[cfg(feature = "runtime")]
-#[instrument]
+#[tracing::instrument]
 pub async fn connect<T>(
     config: &str,
     tls: T,
 ) -> Result<(Client, Connection<Socket, T::Stream>), Error>
 where
-    T: MakeTlsConnect<Socket> + fmt::Debug,
+    T: MakeTlsConnect<Socket> + std::fmt::Debug,
 {
     let config = config.parse::<Config>()?;
     config.connect(tls).await

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -142,6 +142,8 @@ pub use crate::to_statement::ToStatement;
 pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
+use std::fmt;
+use tracing::instrument;
 
 pub mod binary_copy;
 mod bind;
@@ -189,12 +191,13 @@ pub mod types;
 ///
 /// [`Config`]: config/struct.Config.html
 #[cfg(feature = "runtime")]
+#[instrument]
 pub async fn connect<T>(
     config: &str,
     tls: T,
 ) -> Result<(Client, Connection<Socket, T::Stream>), Error>
 where
-    T: MakeTlsConnect<Socket>,
+    T: MakeTlsConnect<Socket> + fmt::Debug,
 {
     let config = config.parse::<Config>()?;
     config.connect(tls).await

--- a/tokio-postgres/src/portal.rs
+++ b/tokio-postgres/src/portal.rs
@@ -5,6 +5,7 @@ use crate::Statement;
 use postgres_protocol::message::frontend;
 use std::sync::{Arc, Weak};
 
+#[derive(Debug)]
 struct Inner {
     client: Weak<InnerClient>,
     name: String,
@@ -28,7 +29,7 @@ impl Drop for Inner {
 ///
 /// Portals can only be used with the connection that created them, and only exist for the duration of the transaction
 /// in which they were created.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Portal(Arc<Inner>);
 
 impl Portal {

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -8,13 +8,13 @@ use crate::{Column, Error, Statement};
 use bytes::Bytes;
 use fallible_iterator::FallibleIterator;
 use futures_util::{pin_mut, TryStreamExt};
-use log::debug;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use tracing::debug;
 
 const TYPEINFO_QUERY: &str = "\
 SELECT t.typname, t.typtype, t.typelem, r.rngsubtype, t.typbasetype, n.nspname, t.typrelid

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -5,7 +5,6 @@ use crate::types::{BorrowToSql, IsNull};
 use crate::{Error, Portal, Row, Statement};
 use bytes::{Bytes, BytesMut};
 use futures_util::{ready, Stream};
-use log::{debug, log_enabled, Level};
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::{CommandCompleteBody, Message};
 use postgres_protocol::message::frontend;
@@ -13,6 +12,7 @@ use std::fmt;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tracing::{debug, Level};
 
 struct BorrowToSqlParamsDebug<'a, T>(&'a [T]);
 
@@ -37,7 +37,7 @@ where
     I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
 {
-    let buf = if log_enabled!(Level::Debug) {
+    let buf = if tracing::enabled!(Level::DEBUG) {
         let params = params.into_iter().collect::<Vec<_>>();
         debug!(
             "executing statement {} with parameters: {:?}",
@@ -101,7 +101,7 @@ where
     I: IntoIterator<Item = P>,
     I::IntoIter: ExactSizeIterator,
 {
-    let buf = if log_enabled!(Level::Debug) {
+    let buf = if tracing::enabled!(Level::DEBUG) {
         let params = params.into_iter().collect::<Vec<_>>();
         debug!(
             "executing statement {} with parameters: {:?}",

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -6,7 +6,6 @@ use crate::{Error, SimpleQueryMessage, SimpleQueryRow};
 use bytes::Bytes;
 use fallible_iterator::FallibleIterator;
 use futures_util::{ready, Stream};
-use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
@@ -14,6 +13,7 @@ use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tracing::debug;
 
 /// Information about a column of a single query row.
 #[derive(Debug)]

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -5,6 +5,7 @@ use crate::types::Type;
 use postgres_protocol::message::frontend;
 use std::sync::{Arc, Weak};
 
+#[derive(Debug)]
 struct StatementInner {
     client: Weak<InnerClient>,
     name: String,
@@ -28,7 +29,7 @@ impl Drop for StatementInner {
 /// A prepared statement.
 ///
 /// Prepared statements can only be used with the connection that created them.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Statement(Arc<StatementInner>);
 
 impl Statement {


### PR DESCRIPTION
Replace `log` with `tracing` as `tracing` is designed for async runtimes.

This paves the way for using `tracing-error::SpanTrace` in `tokio-postgres::Error`.