### PR TITLE
Add postgres-range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "postgres-native-tls",
     "postgres-openssl",
     "postgres-protocol",
+    "postgres-range",
     "postgres-types",
     "tokio-postgres",
     "tokio-postgres-derive",

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -196,7 +196,7 @@ fn composite_body(fields: &[Field]) -> TokenStream {
                 postgres_types::IsNull::Yes => -1,
                 postgres_types::IsNull::No => {
                     let len = buf.len() - base - 4;
-                    if len > i32::max_value() as usize {
+                    if len > i32::MAX as usize {
                         return std::result::Result::Err(
                             std::convert::Into::into("value too large to transmit"));
                     }

--- a/postgres-protocol/src/lib.rs
+++ b/postgres-protocol/src/lib.rs
@@ -60,7 +60,7 @@ macro_rules! from_usize {
         impl FromUsize for $t {
             #[inline]
             fn from_usize(x: usize) -> io::Result<$t> {
-                if x > <$t>::max_value() as usize {
+                if x > <$t>::MAX as usize {
                     Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         "value too large to transmit",

--- a/postgres-range/Cargo.toml
+++ b/postgres-range/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "postgres_range"
+name = "postgres-range"
 version = "0.11.1"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"

--- a/postgres-range/Cargo.toml
+++ b/postgres-range/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sfackler/rust-postgres-range"
 [dependencies]
 postgres-protocol = { path = "../postgres-protocol" }
 postgres-types = { path = "../postgres-types" }
-chrono = { version = "0.4" }
 
 [dev-dependencies]
+chrono = { version = "0.4" }
 postgres = { path = "../postgres", features = ["with-chrono-0_4"] }

--- a/postgres-range/Cargo.toml
+++ b/postgres-range/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "postgres_range"
+version = "0.11.1"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+edition = "2018"
+license = "MIT"
+description = "Range support for rust-postgres"
+repository = "https://github.com/sfackler/rust-postgres-range"
+
+[dependencies]
+postgres-protocol = { path = "../postgres-protocol" }
+postgres-types = { path = "../postgres-types" }
+chrono = { version = "0.4" }
+
+[dev-dependencies]
+postgres = { path = "../postgres", features = ["with-chrono-0_4"] }

--- a/postgres-range/LICENSE
+++ b/postgres-range/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Steven Fackler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/postgres-range/README.md
+++ b/postgres-range/README.md
@@ -1,0 +1,6 @@
+# rust-postgres-range
+[![Build Status](https://travis-ci.org/sfackler/rust-postgres-range.svg?branch=master)](https://travis-ci.org/sfackler/rust-postgres-range)
+
+[Documentation](https://sfackler.github.io/rust-postgres-range/doc/v0.8.2/postgres_range)
+
+Support for PostgreSQL ranges in [rust-postgres](https://github.com/sfackler/rust-postgres).

--- a/postgres-range/src/impls.rs
+++ b/postgres-range/src/impls.rs
@@ -1,0 +1,203 @@
+use std::error::Error;
+
+use postgres_protocol::{self as protocol, types};
+use postgres_types::{private::BytesMut, FromSql, IsNull, Kind, ToSql, Type};
+
+use crate::{BoundSided, BoundType, Range, RangeBound};
+
+impl<'a, T> FromSql<'a> for Range<T>
+where
+    T: PartialOrd + FromSql<'a>,
+{
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Range<T>, Box<dyn Error + Sync + Send>> {
+        let element_type = match *ty.kind() {
+            Kind::Range(ref ty) => ty,
+            _ => panic!("unexpected type {:?}", ty),
+        };
+
+        match types::range_from_sql(raw)? {
+            types::Range::Empty => Ok(Range::empty()),
+            types::Range::Nonempty(lower, upper) => {
+                let lower = bound_from_sql(lower, element_type)?;
+                let upper = bound_from_sql(upper, element_type)?;
+                Ok(Range::new(lower, upper))
+            }
+        }
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        match *ty.kind() {
+            Kind::Range(ref inner) => <T as FromSql>::accepts(inner),
+            _ => false,
+        }
+    }
+}
+
+fn bound_from_sql<'a, T, S>(
+    bound: types::RangeBound<Option<&'a [u8]>>,
+    ty: &Type,
+) -> Result<Option<RangeBound<S, T>>, Box<dyn Error + Sync + Send>>
+where
+    T: PartialOrd + FromSql<'a>,
+    S: BoundSided,
+{
+    match bound {
+        types::RangeBound::Exclusive(value) => {
+            let value = match value {
+                Some(value) => T::from_sql(ty, value)?,
+                None => T::from_sql_null(ty)?,
+            };
+            Ok(Some(RangeBound::new(value, BoundType::Exclusive)))
+        }
+        types::RangeBound::Inclusive(value) => {
+            let value = match value {
+                Some(value) => T::from_sql(ty, value)?,
+                None => T::from_sql_null(ty)?,
+            };
+            Ok(Some(RangeBound::new(value, BoundType::Inclusive)))
+        }
+        types::RangeBound::Unbounded => Ok(None),
+    }
+}
+
+impl<T> ToSql for Range<T>
+where
+    T: PartialOrd + ToSql,
+{
+    fn to_sql(
+        &self,
+        ty: &Type,
+        buf: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        let element_type = match *ty.kind() {
+            Kind::Range(ref ty) => ty,
+            _ => panic!("unexpected type {:?}", ty),
+        };
+
+        if self.is_empty() {
+            types::empty_range_to_sql(buf);
+        } else {
+            types::range_to_sql(
+                |buf| bound_to_sql(self.lower(), element_type, buf),
+                |buf| bound_to_sql(self.upper(), element_type, buf),
+                buf,
+            )?;
+        }
+
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        match *ty.kind() {
+            Kind::Range(ref inner) => <T as ToSql>::accepts(inner),
+            _ => false,
+        }
+    }
+
+    to_sql_checked!();
+}
+
+fn bound_to_sql<S, T>(
+    bound: Option<&RangeBound<S, T>>,
+    ty: &Type,
+    buf: &mut BytesMut,
+) -> Result<types::RangeBound<protocol::IsNull>, Box<dyn Error + Sync + Send>>
+where
+    S: BoundSided,
+    T: ToSql,
+{
+    match bound {
+        Some(bound) => {
+            let null = match bound.value.to_sql(ty, buf)? {
+                IsNull::Yes => protocol::IsNull::Yes,
+                IsNull::No => protocol::IsNull::No,
+            };
+
+            match bound.type_ {
+                BoundType::Exclusive => Ok(types::RangeBound::Exclusive(null)),
+                BoundType::Inclusive => Ok(types::RangeBound::Inclusive(null)),
+            }
+        }
+        None => Ok(types::RangeBound::Unbounded),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fmt;
+
+    use chrono::{Duration, TimeZone, Utc};
+
+    use postgres::{
+        types::{FromSql, ToSql},
+        Client, NoTls,
+    };
+
+    macro_rules! test_range {
+        ($name:expr, $t:ty, $low:expr, $low_str:expr, $high:expr, $high_str:expr) => ({
+            let tests = &[(Some(range!('(',; ')')), "'(,)'".to_string()),
+                         (Some(range!('[' $low,; ')')), format!("'[{},)'", $low_str)),
+                         (Some(range!('(' $low,; ')')), format!("'({},)'", $low_str)),
+                         (Some(range!('(', $high; ']')), format!("'(,{}]'", $high_str)),
+                         (Some(range!('(', $high; ')')), format!("'(,{})'", $high_str)),
+                         (Some(range!('[' $low, $high; ']')),
+                          format!("'[{},{}]'", $low_str, $high_str)),
+                         (Some(range!('[' $low, $high; ')')),
+                          format!("'[{},{})'", $low_str, $high_str)),
+                         (Some(range!('(' $low, $high; ']')),
+                          format!("'({},{}]'", $low_str, $high_str)),
+                         (Some(range!('(' $low, $high; ')')),
+                          format!("'({},{})'", $low_str, $high_str)),
+                         (Some(range!(empty)), "'empty'".to_string()),
+                         (None, "NULL".to_string())];
+            test_type($name, tests);
+        })
+    }
+
+    fn test_type<T, S>(sql_type: &str, checks: &[(T, S)])
+    where
+        for<'a> T: Sync + PartialEq + FromSql<'a> + ToSql,
+        S: fmt::Display,
+    {
+        let mut conn = Client::connect("user=postgres host=localhost port=5433", NoTls).unwrap();
+        for (val, repr) in checks {
+            let stmt = conn
+                .prepare(&format!("SELECT {}::{}", *repr, sql_type))
+                .unwrap();
+            let result = conn.query(&stmt, &[]).unwrap().first().unwrap().get(0);
+            assert_eq!(val, &result);
+
+            let stmt = conn.prepare(&format!("SELECT $1::{}", sql_type)).unwrap();
+            let result = conn.query(&stmt, &[val]).unwrap().first().unwrap().get(0);
+            assert_eq!(val, &result);
+        }
+    }
+
+    #[test]
+    fn test_tsrange_params() {
+        let low = Utc.timestamp_opt(0, 0).unwrap();
+        let high = low + Duration::days(10);
+        test_range!(
+            "TSRANGE",
+            NaiveDateTime,
+            low.naive_utc(),
+            "1970-01-01",
+            high.naive_utc(),
+            "1970-01-11"
+        );
+    }
+
+    #[test]
+    fn test_tstzrange_params() {
+        let low = Utc.timestamp_opt(0, 0).unwrap();
+        let high = low + Duration::days(10);
+        test_range!(
+            "TSTZRANGE",
+            DateTime<Utc>,
+            low,
+            "1970-01-01",
+            high,
+            "1970-01-11"
+        );
+    }
+}

--- a/postgres-range/src/lib.rs
+++ b/postgres-range/src/lib.rs
@@ -5,7 +5,7 @@
 #[macro_use(to_sql_checked)]
 extern crate postgres_types;
 
-use std::{cmp::Ordering, fmt, i32, marker::PhantomData};
+use std::{cmp::Ordering, fmt, marker::PhantomData};
 
 use BoundSide::{Lower, Upper};
 use BoundType::{Exclusive, Inclusive};
@@ -518,8 +518,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::i32;
-
     use super::BoundType::{Exclusive, Inclusive};
     use super::{BoundType, LowerBound, Range, RangeBound, UpperBound};
 

--- a/postgres-range/src/lib.rs
+++ b/postgres-range/src/lib.rs
@@ -1,0 +1,694 @@
+//! Types dealing with ranges of values
+#![doc(html_root_url = "https://sfackler.github.io/rust-postgres-range/doc/v0.11")]
+#![warn(clippy::all, rust_2018_idioms, missing_docs)]
+
+#[macro_use(to_sql_checked)]
+extern crate postgres_types;
+
+use std::{cmp::Ordering, fmt, i32, marker::PhantomData};
+
+use BoundSide::{Lower, Upper};
+use BoundType::{Exclusive, Inclusive};
+use InnerRange::{Empty, Normal};
+
+/// The `range!` macro can make it easier to create ranges. It roughly mirrors
+/// traditional mathematic range syntax.
+///
+/// ## Example
+///
+/// ```rust
+///
+/// #[macro_use]
+/// extern crate postgres_range;
+///
+/// use postgres_range::Range;
+///
+/// fn main() {
+///     let mut r: Range<i32>;
+///     // a closed interval
+///     r = range!('[' 5i32, 10i32; ']');
+///     // an open interval
+///     r = range!('(' 5i32, 10i32; ')');
+///     // half-open intervals
+///     r = range!('(' 5i32, 10i32; ']');
+///     r = range!('[' 5i32, 10i32; ')');
+///     // a closed lower-bounded interval
+///     r = range!('[' 5i32,; ')');
+///     // an open lower-bounded interval
+///     r = range!('(' 5i32,; ')');
+///     // a closed upper-bounded interval
+///     r = range!('(', 10i32; ']');
+///     // an open upper-bounded interval
+///     r = range!('(', 10i32; ')');
+///     // an unbounded interval
+///     r = range!('(',; ')');
+///     // an empty interval
+///     r = range!(empty);
+/// }
+#[macro_export]
+macro_rules! range {
+    (empty) => {
+        $crate::Range::empty()
+    };
+    ('(',; ')') => {
+        $crate::Range::new(None, None)
+    };
+    ('(', $h:expr; ')') => {
+        $crate::Range::new(
+            None,
+            Some($crate::RangeBound::new($h, $crate::BoundType::Exclusive)),
+        )
+    };
+    ('(', $h:expr; ']') => {
+        $crate::Range::new(
+            None,
+            Some($crate::RangeBound::new($h, $crate::BoundType::Inclusive)),
+        )
+    };
+    ('(' $l:expr,; ')') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Exclusive)),
+            None,
+        )
+    };
+    ('[' $l:expr,; ')') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Inclusive)),
+            None,
+        )
+    };
+    ('(' $l:expr, $h:expr; ')') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Exclusive)),
+            Some($crate::RangeBound::new($h, $crate::BoundType::Exclusive)),
+        )
+    };
+    ('(' $l:expr, $h:expr; ']') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Exclusive)),
+            Some($crate::RangeBound::new($h, $crate::BoundType::Inclusive)),
+        )
+    };
+    ('[' $l:expr, $h:expr; ')') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Inclusive)),
+            Some($crate::RangeBound::new($h, $crate::BoundType::Exclusive)),
+        )
+    };
+    ('[' $l:expr, $h:expr; ']') => {
+        $crate::Range::new(
+            Some($crate::RangeBound::new($l, $crate::BoundType::Inclusive)),
+            Some($crate::RangeBound::new($h, $crate::BoundType::Inclusive)),
+        )
+    };
+}
+
+mod impls;
+
+/// The possible sides of a bound.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum BoundSide {
+    /// An upper bound.
+    Upper,
+    /// A lower bound.
+    Lower,
+}
+
+/// A trait implemented by phantom types indicating the type of the bound.
+pub trait BoundSided {
+    /// Returns the bound side this type corresponds to.
+    fn side() -> BoundSide;
+}
+
+/// A tag type representing an upper bound
+pub enum UpperBound {}
+
+/// A tag type representing a lower bound
+pub enum LowerBound {}
+
+impl BoundSided for UpperBound {
+    fn side() -> BoundSide {
+        Upper
+    }
+}
+
+impl BoundSided for LowerBound {
+    fn side() -> BoundSide {
+        Lower
+    }
+}
+
+/// The type of a range bound.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum BoundType {
+    /// The bound includes its value.
+    Inclusive,
+    /// The bound excludes its value.
+    Exclusive,
+}
+
+/// Represents a one-sided bound.
+///
+/// The side is determined by the `S` phantom parameter.
+pub struct RangeBound<S: BoundSided, T> {
+    /// The value of the bound.
+    pub value: T,
+    /// The type of the bound.
+    pub type_: BoundType,
+    _m: PhantomData<S>,
+}
+
+fn _is_send_sync() {
+    fn is_send_sync<T: Send + Sync>() {}
+    is_send_sync::<RangeBound<LowerBound, i32>>();
+}
+
+impl<S, T> Copy for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: Copy,
+{
+}
+
+impl<S, T> Clone for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: Clone,
+{
+    fn clone(&self) -> RangeBound<S, T> {
+        RangeBound {
+            value: self.value.clone(),
+            type_: self.type_,
+            _m: PhantomData,
+        }
+    }
+}
+
+impl<S, T> fmt::Debug for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("RangeBound")
+            .field("value", &self.value)
+            .field("type_", &self.type_)
+            .finish()
+    }
+}
+
+impl<S, T> fmt::Display for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: fmt::Display,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (lower, upper) = match self.type_ {
+            Inclusive => ('[', ']'),
+            Exclusive => ('(', ')'),
+        };
+
+        match <S as BoundSided>::side() {
+            Lower => write!(fmt, "{}{}", lower, self.value),
+            Upper => write!(fmt, "{}{}", self.value, upper),
+        }
+    }
+}
+
+impl<S, T> PartialEq for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: PartialEq,
+{
+    fn eq(&self, other: &RangeBound<S, T>) -> bool {
+        self.value == other.value && self.type_ == other.type_
+    }
+
+    /*fn ne(&self, other: &RangeBound<S, T>) -> bool {
+        self.value != other.value || self.type_ != other.type_
+    }*/
+}
+
+impl<S, T> Eq for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: Eq,
+{
+}
+
+impl<S, T> PartialOrd for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &RangeBound<S, T>) -> Option<Ordering> {
+        match (
+            <S as BoundSided>::side(),
+            self.type_,
+            other.type_,
+            self.value.partial_cmp(&other.value),
+        ) {
+            (Upper, Exclusive, Inclusive, Some(Ordering::Equal))
+            | (Lower, Inclusive, Exclusive, Some(Ordering::Equal)) => Some(Ordering::Less),
+            (Upper, Inclusive, Exclusive, Some(Ordering::Equal))
+            | (Lower, Exclusive, Inclusive, Some(Ordering::Equal)) => Some(Ordering::Greater),
+            (_, _, _, cmp) => cmp,
+        }
+    }
+}
+
+impl<S, T> Ord for RangeBound<S, T>
+where
+    S: BoundSided,
+    T: Ord,
+{
+    fn cmp(&self, other: &RangeBound<S, T>) -> Ordering {
+        match (
+            <S as BoundSided>::side(),
+            self.type_,
+            other.type_,
+            self.value.cmp(&other.value),
+        ) {
+            (Upper, Exclusive, Inclusive, Ordering::Equal)
+            | (Lower, Inclusive, Exclusive, Ordering::Equal) => Ordering::Less,
+            (Upper, Inclusive, Exclusive, Ordering::Equal)
+            | (Lower, Exclusive, Inclusive, Ordering::Equal) => Ordering::Greater,
+            (_, _, _, ord) => ord,
+        }
+    }
+}
+
+impl<S, T> RangeBound<S, T>
+where
+    S: BoundSided,
+    T: PartialOrd,
+{
+    /// Constructs a new range bound
+    pub fn new(value: T, type_: BoundType) -> RangeBound<S, T> {
+        RangeBound {
+            value,
+            type_,
+            _m: PhantomData,
+        }
+    }
+
+    /// Determines if a value lies within the range specified by this bound.
+    pub fn in_bounds(&self, value: &T) -> bool {
+        match (self.type_, <S as BoundSided>::side()) {
+            (Inclusive, Upper) => value <= &self.value,
+            (Exclusive, Upper) => value < &self.value,
+            (Inclusive, Lower) => value >= &self.value,
+            (Exclusive, Lower) => value > &self.value,
+        }
+    }
+}
+
+struct OptBound<'a, S: BoundSided, T>(Option<&'a RangeBound<S, T>>);
+
+impl<'a, S, T> PartialEq for OptBound<'a, S, T>
+where
+    S: BoundSided,
+    T: PartialEq,
+{
+    fn eq(&self, OptBound(other): &OptBound<'a, S, T>) -> bool {
+        let OptBound(self_) = self;
+        self_ == other
+    }
+}
+
+impl<'a, S, T> PartialOrd for OptBound<'a, S, T>
+where
+    S: BoundSided,
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &OptBound<'a, S, T>) -> Option<Ordering> {
+        match (self, other, <S as BoundSided>::side()) {
+            (&OptBound(None), &OptBound(None), _) => Some(Ordering::Equal),
+            (&OptBound(None), _, Lower) | (_, &OptBound(None), Upper) => Some(Ordering::Less),
+            (&OptBound(None), _, Upper) | (_, &OptBound(None), Lower) => Some(Ordering::Greater),
+            (&OptBound(Some(a)), &OptBound(Some(b)), _) => a.partial_cmp(b),
+        }
+    }
+}
+
+/// Represents a range of values.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Range<T> {
+    inner: InnerRange<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum InnerRange<T> {
+    Empty,
+    Normal(
+        Option<RangeBound<LowerBound, T>>,
+        Option<RangeBound<UpperBound, T>>,
+    ),
+}
+
+impl<T> fmt::Display for Range<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.inner {
+            Empty => write!(fmt, "empty"),
+            Normal(ref lower, ref upper) => {
+                match *lower {
+                    Some(ref bound) => write!(fmt, "{}", bound)?,
+                    None => write!(fmt, "(")?,
+                }
+                write!(fmt, ",")?;
+                match *upper {
+                    Some(ref bound) => write!(fmt, "{}", bound),
+                    None => write!(fmt, ")"),
+                }
+            }
+        }
+    }
+}
+
+impl<T> Range<T>
+where
+    T: PartialOrd,
+{
+    /// Creates a new range.
+    ///
+    /// If a bound is `None`, the range is unbounded in that direction.
+    pub fn new(
+        lower: Option<RangeBound<LowerBound, T>>,
+        upper: Option<RangeBound<UpperBound, T>>,
+    ) -> Range<T> {
+        if let (Some(lower), Some(upper)) = (&lower, &upper) {
+            let empty = match (lower.type_, upper.type_) {
+                (Inclusive, Inclusive) => lower.value > upper.value,
+                _ => lower.value >= upper.value,
+            };
+            if empty {
+                return Range { inner: Empty };
+            }
+        }
+
+        Range {
+            inner: Normal(lower, upper),
+        }
+    }
+
+    /// Creates a new empty range.
+    pub fn empty() -> Range<T> {
+        Range { inner: Empty }
+    }
+
+    /// Determines if this range is the empty range.
+    pub fn is_empty(&self) -> bool {
+        match self.inner {
+            Empty => true,
+            Normal(..) => false,
+        }
+    }
+
+    /// Returns the lower bound if it exists.
+    pub fn lower(&self) -> Option<&RangeBound<LowerBound, T>> {
+        match self.inner {
+            Normal(Some(ref lower), _) => Some(lower),
+            _ => None,
+        }
+    }
+
+    /// Returns the upper bound if it exists.
+    pub fn upper(&self) -> Option<&RangeBound<UpperBound, T>> {
+        match self.inner {
+            Normal(_, Some(ref upper)) => Some(upper),
+            _ => None,
+        }
+    }
+
+    /// Determines if a value lies within this range.
+    pub fn contains(&self, value: &T) -> bool {
+        match self.inner {
+            Empty => false,
+            Normal(ref lower, ref upper) => {
+                lower.as_ref().map_or(true, |b| b.in_bounds(value))
+                    && upper.as_ref().map_or(true, |b| b.in_bounds(value))
+            }
+        }
+    }
+
+    /// Determines if a range lies completely within this range.
+    pub fn contains_range(&self, other: &Range<T>) -> bool {
+        if other.is_empty() {
+            return true;
+        }
+
+        if self.is_empty() {
+            return false;
+        }
+
+        OptBound(self.lower()) <= OptBound(other.lower())
+            && OptBound(self.upper()) >= OptBound(other.upper())
+    }
+}
+
+fn order<T>(a: T, b: T) -> (T, T)
+where
+    T: PartialOrd,
+{
+    if a < b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+impl<T> Range<T>
+where
+    T: PartialOrd + Clone,
+{
+    /// Returns the intersection of this range with another.
+    pub fn intersect(&self, other: &Range<T>) -> Range<T> {
+        if self.is_empty() || other.is_empty() {
+            return Range::empty();
+        }
+
+        let (_, OptBound(lower)) = order(OptBound(self.lower()), OptBound(other.lower()));
+        let (OptBound(upper), _) = order(OptBound(self.upper()), OptBound(other.upper()));
+
+        Range::new(lower.cloned(), upper.cloned())
+    }
+
+    /// Returns the union of this range with another if it is contiguous.
+    pub fn union(&self, other: &Range<T>) -> Option<Range<T>> {
+        if self.is_empty() {
+            return Some(other.clone());
+        }
+
+        if other.is_empty() {
+            return Some(self.clone());
+        }
+
+        let (OptBound(l_lower), OptBound(u_lower)) =
+            order(OptBound(self.lower()), OptBound(other.lower()));
+        let (OptBound(l_upper), OptBound(u_upper)) =
+            order(OptBound(self.upper()), OptBound(other.upper()));
+
+        let discontiguous = match (u_lower, l_upper) {
+            (
+                Some(&RangeBound {
+                    value: ref l,
+                    type_: Exclusive,
+                    ..
+                }),
+                Some(&RangeBound {
+                    value: ref u,
+                    type_: Exclusive,
+                    ..
+                }),
+            ) => l >= u,
+            (Some(RangeBound { value: l, .. }), Some(RangeBound { value: u, .. })) => l > u,
+            _ => false,
+        };
+
+        if discontiguous {
+            None
+        } else {
+            Some(Range::new(l_lower.cloned(), u_upper.cloned()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::i32;
+
+    use super::BoundType::{Exclusive, Inclusive};
+    use super::{BoundType, LowerBound, Range, RangeBound, UpperBound};
+
+    #[test]
+    fn test_range_bound_lower_lt() {
+        fn check(val1: isize, inc1: BoundType, val2: isize, inc2: BoundType, expected: bool) {
+            let a: RangeBound<LowerBound, isize> = RangeBound::new(val1, inc1);
+            let b: RangeBound<LowerBound, isize> = RangeBound::new(val2, inc2);
+            assert_eq!(expected, a < b);
+        }
+
+        check(1, Inclusive, 2, Exclusive, true);
+        check(1, Exclusive, 2, Inclusive, true);
+        check(1, Inclusive, 1, Exclusive, true);
+        check(2, Inclusive, 1, Inclusive, false);
+        check(2, Exclusive, 1, Exclusive, false);
+        check(1, Exclusive, 1, Inclusive, false);
+        check(1, Exclusive, 1, Exclusive, false);
+        check(1, Inclusive, 1, Inclusive, false);
+    }
+
+    #[test]
+    fn test_range_bound_upper_lt() {
+        fn check(val1: isize, inc1: BoundType, val2: isize, inc2: BoundType, expected: bool) {
+            let a: RangeBound<UpperBound, isize> = RangeBound::new(val1, inc1);
+            let b: RangeBound<UpperBound, isize> = RangeBound::new(val2, inc2);
+            assert_eq!(expected, a < b);
+        }
+
+        check(1, Inclusive, 2, Exclusive, true);
+        check(1, Exclusive, 2, Exclusive, true);
+        check(1, Exclusive, 1, Inclusive, true);
+        check(2, Inclusive, 1, Inclusive, false);
+        check(2, Exclusive, 1, Exclusive, false);
+        check(1, Inclusive, 1, Exclusive, false);
+        check(1, Inclusive, 1, Inclusive, false);
+        check(1, Exclusive, 1, Exclusive, false);
+    }
+
+    #[test]
+    fn test_range_bound_lower_in_bounds() {
+        fn check(bound: isize, inc: BoundType, val: isize, expected: bool) {
+            let b: RangeBound<LowerBound, isize> = RangeBound::new(bound, inc);
+            assert_eq!(expected, b.in_bounds(&val));
+        }
+
+        check(1, Inclusive, 1, true);
+        check(1, Exclusive, 1, false);
+        check(1, Inclusive, 2, true);
+        check(1, Inclusive, 0, false);
+    }
+
+    #[test]
+    fn test_range_bound_upper_in_bounds() {
+        fn check(bound: isize, inc: BoundType, val: isize, expected: bool) {
+            let b: RangeBound<UpperBound, isize> = RangeBound::new(bound, inc);
+            assert_eq!(expected, b.in_bounds(&val));
+        }
+
+        check(1, Inclusive, 1, true);
+        check(1, Exclusive, 1, false);
+        check(1, Inclusive, 2, false);
+        check(1, Inclusive, 0, true);
+    }
+
+    #[test]
+    fn test_range_contains() {
+        let r = range!('[' 1i32, 3i32; ']');
+        assert!(!r.contains(&4));
+        assert!(r.contains(&3));
+        assert!(r.contains(&2));
+        assert!(r.contains(&1));
+        assert!(!r.contains(&0));
+
+        let r = range!('(' 1i32, 3i32; ')');
+        assert!(!r.contains(&4));
+        assert!(!r.contains(&3));
+        assert!(r.contains(&2));
+        assert!(!r.contains(&1));
+        assert!(!r.contains(&0));
+
+        let r = range!('(', 3i32; ']');
+        assert!(!r.contains(&4));
+        assert!(r.contains(&2));
+        assert!(r.contains(&i32::MIN));
+
+        let r = range!('[' 1i32,; ')');
+        assert!(r.contains(&i32::MAX));
+        assert!(r.contains(&4));
+        assert!(!r.contains(&0));
+
+        let r = range!('(',; ')');
+        assert!(r.contains(&i32::MAX));
+        assert!(r.contains(&0i32));
+        assert!(r.contains(&i32::MIN));
+    }
+
+    #[test]
+    fn test_intersection() {
+        let r1 = range!('[' 10i32, 15i32; ')');
+        let r2 = range!('(' 20i32, 25i32; ']');
+        assert!(r1.intersect(&r2).is_empty());
+        assert!(r2.intersect(&r1).is_empty());
+        assert_eq!(r1, r1.intersect(&range!('(',; ')')));
+        assert_eq!(r1, (range!('(',; ')')).intersect(&r1));
+
+        let r2 = range!('(' 10i32,; ')');
+        let exp = Range::new(r2.lower().copied(), r1.upper().copied());
+        assert_eq!(exp, r1.intersect(&r2));
+        assert_eq!(exp, r2.intersect(&r1));
+
+        let r2 = range!('(', 15i32; ']');
+        assert_eq!(r1, r1.intersect(&r2));
+        assert_eq!(r1, r2.intersect(&r1));
+
+        let r2 = range!('[' 11i32, 14i32; ')');
+        assert_eq!(r2, r1.intersect(&r2));
+        assert_eq!(r2, r2.intersect(&r1));
+    }
+
+    #[test]
+    fn test_union() {
+        let r1 = range!('[' 10i32, 15i32; ')');
+        let r2 = range!('(' 20i32, 25i32; ']');
+        assert_eq!(None, r1.union(&r2));
+        assert_eq!(None, r2.union(&r1));
+
+        let r2 = range!('(',; ')');
+        assert_eq!(Some(r2), r1.union(&r2));
+        assert_eq!(Some(r2), r2.union(&r1));
+
+        let r2 = range!('[' 13i32, 50i32; ')');
+        assert_eq!(Some(range!('[' 10i32, 50i32; ')')), r1.union(&r2));
+        assert_eq!(Some(range!('[' 10i32, 50i32; ')')), r2.union(&r1));
+
+        let r2 = range!('[' 3i32, 50i32; ')');
+        assert_eq!(Some(range!('[' 3i32, 50i32; ')')), r1.union(&r2));
+        assert_eq!(Some(range!('[' 3i32, 50i32; ')')), r2.union(&r1));
+
+        let r2 = range!('(', 11i32; ')');
+        assert_eq!(Some(range!('(', 15i32; ')')), r1.union(&r2));
+        assert_eq!(Some(range!('(', 15i32; ')')), r2.union(&r1));
+
+        let r2 = range!('(' 11i32,; ')');
+        assert_eq!(Some(range!('[' 10i32,; ')')), r1.union(&r2));
+        assert_eq!(Some(range!('[' 10i32,; ')')), r2.union(&r1));
+
+        let r2 = range!('(' 15i32, 20i32; ')');
+        assert_eq!(None, r1.union(&r2));
+        assert_eq!(None, r2.union(&r1));
+
+        let r2 = range!('[' 15i32, 20i32; ']');
+        assert_eq!(Some(range!('[' 10i32, 20i32; ']')), r1.union(&r2));
+        assert_eq!(Some(range!('[' 10i32, 20i32; ']')), r2.union(&r1));
+    }
+
+    #[test]
+    fn test_contains_range() {
+        assert!(Range::<i32>::empty().contains_range(&Range::empty()));
+
+        let r1 = range!('[' 10i32, 15i32; ')');
+        assert!(r1.contains_range(&r1));
+
+        let r2 = range!('(' 10i32,; ')');
+        assert!(!r1.contains_range(&r2));
+        assert!(!r2.contains_range(&r1));
+
+        let r2 = range!('(', 15i32; ']');
+        assert!(!r1.contains_range(&r2));
+        assert!(r2.contains_range(&r1));
+    }
+}

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -123,7 +123,7 @@ impl<'a> FromSql<'a> for NaiveDate {
 impl ToSql for NaiveDate {
     fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         let jd = self.signed_duration_since(base().date()).num_days();
-        if jd > i64::from(i32::max_value()) || jd < i64::from(i32::min_value()) {
+        if jd > i64::from(i32::MAX) || jd < i64::from(i32::MIN) {
             return Err("value too large to transmit".into());
         }
 

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -1285,7 +1285,7 @@ impl ToSql for IpAddr {
 }
 
 fn downcast(len: usize) -> Result<i32, Box<dyn Error + Sync + Send>> {
-    if len > i32::max_value() as usize {
+    if len > i32::MAX as usize {
         Err("value too large to transmit".into())
     } else {
         Ok(len as i32)

--- a/postgres-types/src/special.rs
+++ b/postgres-types/src/special.rs
@@ -1,7 +1,6 @@
 use bytes::BytesMut;
 use postgres_protocol::types;
 use std::error::Error;
-use std::{i32, i64};
 
 use crate::{FromSql, IsNull, ToSql, Type};
 

--- a/postgres-types/src/time_02.rs
+++ b/postgres-types/src/time_02.rs
@@ -72,7 +72,7 @@ impl<'a> FromSql<'a> for Date {
 impl ToSql for Date {
     fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         let jd = (*self - base().date()).whole_days();
-        if jd > i64::from(i32::max_value()) || jd < i64::from(i32::min_value()) {
+        if jd > i64::from(i32::MAX) || jd < i64::from(i32::MIN) {
             return Err("value too large to transmit".into());
         }
 

--- a/postgres-types/src/time_03.rs
+++ b/postgres-types/src/time_03.rs
@@ -71,7 +71,7 @@ impl<'a> FromSql<'a> for Date {
 impl ToSql for Date {
     fn to_sql(&self, _: &Type, w: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
         let jd = (*self - base().date()).whole_days();
-        if jd > i64::from(i32::max_value()) || jd < i64::from(i32::min_value()) {
+        if jd > i64::from(i32::MAX) || jd < i64::from(i32::MIN) {
             return Err("value too large to transmit".into());
         }
 


### PR DESCRIPTION
Added postgres range from here https://github.com/sfackler/rust-postgres-range and removed `Normalizable` and it's implementations, see also https://github.com/sfackler/rust-postgres-range/issues/7#issuecomment-360022853.

Also removed chrono as a feature because I don't see a reason to use range without chrono. Btw, chrono is a dev-dependency.

Also clippy  fixes (rustc 1.79).