### PR TITLE
Format position in sql

### DIFF
--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -257,17 +257,14 @@ impl DbError {
         let mut before_str = before[before.len().saturating_sub(2)..].join("\n");
         before_str.push_str(after.first().copied().unwrap_or_default());
 
-        let after_str = after.get(1).copied().unwrap_or_default();
+        let indent = before.last().copied().unwrap_or_default().chars().count();
+        let mut out = format!("{before_str}\n{:width$}^", "", width = indent);
 
-        let indent = before.last().copied().unwrap_or_default().len();
+        if let Some(after_str) = after.get(1).copied() {
+            out = format!("{out}\n{after_str}")
+        }
 
-        Some(format!(
-            "{before_str}\n
-{:width$}^
-{after_str}",
-            "",
-            width = indent
-        ))
+        Some(out)
     }
 
     /// An indication of the context in which the error occurred.

--- a/tokio-postgres/src/error/mod.rs
+++ b/tokio-postgres/src/error/mod.rs
@@ -250,10 +250,10 @@ impl DbError {
             ErrorPosition::Original(idx) => (self.statement.as_deref()?, *idx),
             ErrorPosition::Internal { position, query } => (query.as_str(), *position),
         };
-        let (first, last) = sql.split_at_checked(pos as usize)?;
+        let (first, last) = sql.split_at_checked(pos.saturating_sub(1) as usize)?;
         let first = first.lines().last().unwrap_or_default();
         let last = last.lines().next().unwrap_or_default();
-        Some(format!("{first}{{!ERROR!}}{last}"))
+        Some(format!("{first}/*ERROR =>*/{last}"))
     }
 
     /// An indication of the context in which the error occurred.

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -66,7 +66,11 @@ pub async fn prepare(
     let buf = encode(client, &name, query, types)?;
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
-    match responses.next().await? {
+    match responses
+        .next()
+        .await
+        .map_err(|e| e.with_statement(query))?
+    {
         Message::ParseComplete => {}
         _ => return Err(Error::unexpected_message()),
     }


### PR DESCRIPTION
This adds more detail to errors when preparing a statement fails due to a syntax error or unknown column.
Errors now look like this:
```
db error: ERROR: column "invalid_field" does not exist
SQL: SELECT /*ERROR =>*/invalid_field FROM test_user WHERE name = $1;
```
It includes a single line of the SQL code and inserts the `/*ERROR =>*/` comment